### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 GroundDocs is a version-aware Kubernetes documentation assistant. It connects LLMs to trusted, real-time Kubernetes docs—reducing hallucinations and ensuring accurate, version-specific responses.
 
+<a href="https://glama.ai/mcp/servers/@GroundDocs/grounddocs">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GroundDocs/grounddocs/badge" alt="GroundDocs MCP server" />
+</a>
+
 ## 🚀 Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [GroundDocs](https://glama.ai/mcp/servers/@GroundDocs/grounddocs) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@GroundDocs/grounddocs">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@GroundDocs/grounddocs/badge" alt="GroundDocs MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.